### PR TITLE
refactor: remove startup toast "Hi there"

### DIFF
--- a/src/pages/MainPanel.vue
+++ b/src/pages/MainPanel.vue
@@ -87,8 +87,6 @@ export default {
         this.evbc_disconnected = false;
       }
     });
-
-    this.$store.commit("snackbar_message", { text: "Hi there", color: "blue", timeout: 3142 });
   },
   computed: {
     snackbar() {
@@ -97,7 +95,7 @@ export default {
   },
   watch: {
     snackbar(sb) {
-      this.show_snackbar = sb === undefined ? false : true;
+      this.show_snackbar = sb !== undefined;
     },
   },
 };


### PR DESCRIPTION
This was always intended as a proof of concept for the toasts and we don't need it anymore.