### PR TITLE
fix(stage): zooming behavior for trackpads + zoom center point

### DIFF
--- a/src/components/EvConfigCanvas.vue
+++ b/src/components/EvConfigCanvas.vue
@@ -33,7 +33,7 @@ export default defineComponent({
             container: "konva-stage",
             width: 1024, // will automatically be resized responsively
             height: 800,
-            draggable: true,
+            draggable: false, // we only want to have the static layer draggable
           },
           evbcStore.config_context
       );

--- a/src/modules/evconf_konva/views/constants.ts
+++ b/src/modules/evconf_konva/views/constants.ts
@@ -34,6 +34,6 @@ export const TEXT = {
 export const TOOLTIP = {
   position: {
     x: 10,
-    y: 770,
+    y: 10,
   },
 };


### PR DESCRIPTION
When the stage was dragged, the center of the zoom point wasn't the
cursor anymore. Additionally zooming on a macbook mousepad was very
fast.

Closes #11

Signed-off-by: Lukas Mertens <git@lukas-mertens.de>

---

**Stack**:
- #44
- #43
- #42
- #34
- #33
- #32
- #31
- #29
- #27
- #26
- #25 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*