### PR TITLE
fix(stage-tooltip): added background for better readability

### DIFF
--- a/src/modules/evconf_konva/config_stage.ts
+++ b/src/modules/evconf_konva/config_stage.ts
@@ -50,9 +50,29 @@ export default class ConfigStage {
       fontFamily: TEXT.fontFamily,
       fontSize: 16,
       padding: 5,
-      fill: 'black',
+      fill: 'white',
       alpha: 0.75,
       visible: false,
+      sceneFunc: function(context, shape) {
+        const {width, height} = shape.size();
+        const borderRadius = 3;
+
+        context.beginPath();
+        context.moveTo(borderRadius, 0);
+        context.lineTo(width - borderRadius, 0);
+        context.arcTo(width, 0, width, borderRadius, borderRadius);
+        context.lineTo(width, height - borderRadius);
+        context.arcTo(width, height, width - borderRadius, height, borderRadius);
+        context.lineTo(borderRadius, height);
+        context.arcTo(0, height, 0, height - borderRadius, borderRadius);
+        context.lineTo(0, borderRadius);
+        context.arcTo(0, 0, borderRadius, 0, borderRadius);
+        context.closePath();
+        context.fillStyle = 'rgb(33, 150, 243)';
+        context.fill();
+
+        (shape as Konva.Text)._sceneFunc(context);
+      },
       ...TOOLTIP.position
     });
 


### PR DESCRIPTION
Without a background the text is not readable if other elements are
below the tooltip

Closes #24

Signed-off-by: Lukas Mertens <git@lukas-mertens.de>

---

**Stack**:
- #44
- #43
- #42
- #34
- #33 ⬅
- #32
- #31
- #29
- #27
- #26
- #25


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*