### PR TITLE
fix(stage): only cache module nodes if they contain children

### DIFF
--- a/src/modules/evconf_konva/views/module.ts
+++ b/src/modules/evconf_konva/views/module.ts
@@ -228,10 +228,14 @@ export default class ModuleView {
       ev.normal.forEach((id) => {
         this._terminal_views[id].set_appearence("NORMAL");
       });
-      this.group.cache();
+      if (this.group.children.length > 0) {
+        this.group.cache();
+      }
     } else if (ev.type === "MODULE_MODEL_UPDATE") {
       this._title.setText(this._vm.id);
-      this.group.cache();
+      if (this.group.children.length > 0) {
+        this.group.cache();
+      }
     }
   }
 
@@ -315,7 +319,9 @@ export default class ModuleView {
     const end_align = this._vm.terminal_lookup[view.terminal_id].alignment;
 
     this._recalculate_terminal_position(end_align, this._vm.terminal_dist[end_align]);
-    this.group.cache();
+    if (this.group.children.length > 0) {
+      this.group.cache();
+    }
   }
 
   _recalculate_terminal_position(alignment: TerminalAlignment, terminal_ids: number[], animate = false) {


### PR DESCRIPTION
Otherwise caching will result in an error, so we skip it in cases where
no children are present.

Closes #84

Signed-off-by: Lukas Mertens <git@lukas-mertens.de>

---

**Stack**:
- #164
- #161
- #160
- #154
- #153
- #140
- #139 ⬅
- #138
- #136
- #148
- #135
- #147
- #134
- #132
- #129
- #130
- #128
- #127
- #126
- #125
- #146


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*