### PR TITLE
chore(loopbackRpcIssuer): reduced random wait

### DIFF
--- a/src/modules/evbc/connection.ts
+++ b/src/modules/evbc/connection.ts
@@ -5,7 +5,8 @@ import {RpcIssuer} from "./rpc/abstractRpcIssuer";
 import {LoopbackRpcIssuer} from "@/modules/evbc/rpc/loopbackRpcIssuer";
 import {WebsocketRpcIssuer} from "@/modules/evbc/rpc/websocketRpcIssuer";
 
-export const LOOPBACK_WAIT_MS = 500;
+// set a value greater than 0 to simulate a delay in the loopback mode
+export const LOOPBACK_WAIT_MS = 0;
 
 type ConnectionOpenStatus = {
   type: "OPEN";


### PR DESCRIPTION
In most cases the random wait doesn't help, as users just want to use
the admin panel, not test how it reacts to bad network condition. For
now I just reduced it, maybe later we can add a toggle

Signed-off-by: Lukas Mertens <git@lukas-mertens.de>

---

**Stack**:
- #164
- #161 ⬅
- #160
- #154
- #153
- #140
- #139
- #138
- #136
- #148
- #135
- #147
- #134
- #132
- #129
- #130
- #128
- #127
- #126
- #125
- #146


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*