### PR TITLE
refactor(CreateConfig): use correct type for validateConfigContent

### DIFF
--- a/src/components/CreateConfig.vue
+++ b/src/components/CreateConfig.vue
@@ -162,7 +162,7 @@ function uploadConfigPrompt() {
 /**
  * Validates that the config content is a valid JSON or YAML config
  */
-async function validateConfigContent(content: object): Promise<true | string> {
+async function validateConfigContent(content: unknown): Promise<true | string> {
   const ajv = new Ajv();
   const schema = await getConfigJsonSchema();
   const validate = ajv.compile(schema);


### PR DESCRIPTION
The result of yaml.load is of type "unknown", not "object", so we can't
assume the input to validateConfigContent is even an object.

Noticed while fixing all errors caused by executing vue-tsc

Signed-off-by: Lukas Mertens <git@lukas-mertens.de>