### PR TITLE
test(e2e): added basic config creation e2e test

### DIFF
--- a/cypress/e2e/create-simple-config.cy.ts
+++ b/cypress/e2e/create-simple-config.cy.ts
@@ -6,10 +6,11 @@
 describe("create a simple config", () => {
   it("should create a config successfully", () => {
     cy.visit("/");
-    cy.contains("div", "Simulator / Mock").click();
-    cy.get(".mdi-plus").click();
-    cy.get("input").type("simple-config");
-    cy.get(".mdi-check").click();
+    cy.get("[data-cy='server-list-item']:nth-child(1)").click();
+    cy.get("[data-cy='plus-create-config-btn']").click();
+    cy.get("[data-cy='config-name-input']").type("simple-config");
+    cy.get("[data-cy='accept-create-config-btn']").click();
+    // these should be fine without data-cy as they are dynamically generated and there should be only one module named eg. EvseManager
     cy.contains("div", "EvseManager").click();
     cy.contains("div", "YetiDriver").click();
     const canvas = cy.get("#konva-stage");
@@ -36,8 +37,8 @@ describe("create a simple config", () => {
     // canvas.trigger("mouseup", 330, 465);
 
     cy.get("#show-preview-button").click();
-    cy.get(".v-slide-group__content").should("be.visible");
-    cy.get(".hljs").should(
+    cy.get("[data-cy='download-config-file-button']").should("be.visible");
+    cy.get("[data-cy='config-preview-component'").should(
       "contain.text",
       "EvseManager0:\n    module: EvseManager",
     );

--- a/cypress/e2e/create-simple-config.cy.ts
+++ b/cypress/e2e/create-simple-config.cy.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
 /// <reference types="cypress" />
 
 describe("create a simple config", () => {

--- a/cypress/e2e/create-simple-config.cy.ts
+++ b/cypress/e2e/create-simple-config.cy.ts
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+
+describe("create a simple config", () => {
+  it("should create a config successfully", () => {
+    cy.visit("/");
+    cy.contains("div", "Simulator / Mock").click();
+    cy.get(".mdi-plus").click();
+    cy.get("input").type("simple-config");
+    cy.get(".mdi-check").click();
+    cy.contains("div", "EvseManager").click();
+    cy.contains("div", "YetiDriver").click();
+    const canvas = cy.get("#konva-stage");
+
+    canvas.should("be.visible");
+
+    canvas.trigger("mousedown", 100, 100);
+    canvas.trigger("mousemove", 100, 400);
+    canvas.trigger("mouseup", 100, 400);
+
+    canvas.trigger("mousedown", 100, 100);
+    canvas.trigger("mousemove", 130, 100);
+    canvas.trigger("mouseup", 130, 100);
+
+    // TODO: try connecting 2 modules
+    // canvas.trigger("mousedown", 10, 2);
+    // canvas.trigger("mousemove", 10, 3);
+    // // cy.wait(10);
+    // canvas.trigger("mouseup", 10, 2);
+    // cy.wait(500);
+    // canvas.trigger("mousedown", 330, 465);
+    // canvas.trigger("mousemove", 330, 466);
+    // // cy.wait(10);
+    // canvas.trigger("mouseup", 330, 465);
+
+    cy.get("#show-preview-button").click();
+    cy.get(".v-slide-group__content").should("be.visible");
+    cy.get(".hljs").should(
+      "contain.text",
+      "EvseManager0:\n    module: EvseManager",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "eslint --ignore-path .gitignore --fix .",
     "test": "vitest",
-    "test:coverage": "vitest --coverage.enabled true"
+    "test:coverage": "vitest --coverage.enabled true",
+    "test:e2e": "cypress run",
+    "test:e2e:open": "cypress open"
   },
   "type": "module",
   "dependencies": {

--- a/src/components/ConfigPreview.vue
+++ b/src/components/ConfigPreview.vue
@@ -10,7 +10,7 @@
         <v-card-title>
           <div class="title-content">
             <div class="controls">
-              <v-btn icon="mdi-download" @click="downloadConfig()" />
+              <v-btn icon="mdi-download" data-cy="download-config-file-button" @click="downloadConfig()" />
               <v-btn icon="mdi-content-copy" @click="copyConfig()" />
             </div>
             <v-btn class="close-button" icon="mdi-close" variant="plain" density="compact" @click="closeDialog()" />
@@ -22,7 +22,7 @@
           </v-tabs>
           <v-window v-model="tab">
             <v-window-item value="yaml">
-              <highlightjs language="yaml" :code="yamlCode" />
+              <highlightjs language="yaml" :code="yamlCode" data-cy="config-preview-component" />
             </v-window-item>
           </v-window>
         </v-card-text>


### PR DESCRIPTION
### TL;DR
Added Cypress E2E test for creating a simple configuration and included new test scripts in package.json.

### What changed?
- Created a new Cypress test file that validates the basic configuration creation flow
- Added test scripts in package.json for running Cypress tests:
  - `test:e2e`: Run Cypress tests in headless mode
  - `test:e2e:open`: Open Cypress test runner in interactive mode

### How to test?
1. Run `npm run test:e2e:open` to open Cypress test runner
2. Select `create-simple-config.cy.ts` test
3. Verify that the test successfully:
   - Creates a new configuration
   - Adds EvseManager and YetiDriver modules
   - Performs canvas interactions
   - Validates the configuration preview

### Why make this change?
To ensure the basic configuration creation workflow remains functional through automated testing, reducing the risk of regressions and improving overall application reliability.