### PR TITLE
added incorrect config on import

### DIFF
--- a/cypress/e2e/config-management.cy.ts
+++ b/cypress/e2e/config-management.cy.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+/// <reference types="cypress" />
+
 import { faker } from "@faker-js/faker";
 
 describe("ConfigManagement", () => {

--- a/src/components/CreateConfig.vue
+++ b/src/components/CreateConfig.vue
@@ -111,8 +111,11 @@ const showErrorDialog = computed(() => errors.hasError);
 
 function onAcceptBtnClick() {
   if (validateConfigName() === true) {
-    resetDialog();
+    errors.clearError();
+    state.value = ComponentStates.DEFAULT;
     emit("createConfig", configName.value, configContent.value ?? undefined);
+    configName.value = "";
+    configContent.value = null;
   }
 }
 

--- a/src/components/CreateConfig.vue
+++ b/src/components/CreateConfig.vue
@@ -73,7 +73,7 @@
     <v-card color="danger">
       <v-card-title>Couldn't load config</v-card-title>
       <v-card-text>
-        <pre style="white-space: pre-wrap"><code>{{ errors.getError() }}</code></pre>
+        <pre style="white-space: pre-wrap"><code>{{ errorStore.getError() }}</code></pre>
       </v-card-text>
       <v-card-actions>
         <v-btn color="primary" @click="resetDialog()"> OK </v-btn>
@@ -106,12 +106,12 @@ const emit = defineEmits<{
 }>();
 const { available_configs } = storeToRefs(evbcStore);
 const configContent = ref<EverestConfig>(null);
-const errors = useErrorStore();
-const showErrorDialog = computed(() => errors.hasError);
+const errorStore = useErrorStore();
+const showErrorDialog = computed(() => errorStore.hasError);
 
 function onAcceptBtnClick() {
   if (validateConfigName() === true) {
-    errors.clearError();
+    errorStore.clearError();
     state.value = ComponentStates.DEFAULT;
     emit("createConfig", configName.value, configContent.value ?? undefined);
     configName.value = "";
@@ -123,7 +123,7 @@ function resetDialog() {
   state.value = ComponentStates.DEFAULT;
   configName.value = "";
   configContent.value = null;
-  errors.clearError();
+  errorStore.clearError();
 }
 
 function uploadConfigPrompt() {
@@ -142,7 +142,7 @@ function uploadConfigPrompt() {
           configName.value = file.name.replace(/\.[^.]+$/, ""); // remove file extension
           state.value = ComponentStates.ASK_USER_FOR_CONFIG_NAME;
         } else {
-          errors.setError(parseResult.errors);
+          errorStore.setError(parseResult.errors);
         }
       };
       reader.readAsText(file);

--- a/src/components/EvModuleList.vue
+++ b/src/components/EvModuleList.vue
@@ -176,7 +176,6 @@ function create_config(name: string, content?: EverestConfig) {
     expansionPanelState.value = ["modules"];
   } catch (err) {
     errorStore.setError(err.toString());
-    console.log(`error in config: ${errorStore.getError()}`);
   }
 }
 

--- a/src/components/EvModuleList.vue
+++ b/src/components/EvModuleList.vue
@@ -84,8 +84,8 @@
   </v-expansion-panels>
 </template>
 
-<script lang="ts">
-import { defineComponent, inject } from "vue";
+<script setup lang="ts">
+import { ref, computed, inject } from "vue";
 import { useEvbcStore } from "@/store/evbc";
 import EVBackendClient from "@/modules/evbc/client";
 import EvDialog from "@/components/EvDialog.vue";
@@ -93,132 +93,121 @@ import EVConfigModel from "@/modules/evbc/config_model";
 import { Notyf } from "notyf";
 import CreateConfig from "@/components/CreateConfig.vue";
 import { EverestConfig } from "@/modules/evbc";
+import { useErrorStore } from "@/store/errorStore";
 
-let evbcStore: ReturnType<typeof useEvbcStore>;
-let evbc: EVBackendClient;
-let notyf: Notyf;
+const evbcStore = useEvbcStore();
+const errorStore = useErrorStore();
+const evbc = inject<EVBackendClient>("evbc") as EVBackendClient;
+const notyf = inject<Notyf>("notyf");
 
-export default defineComponent({
-  components: { CreateConfig, EvDialog },
-  data: () => {
-    return {
-      show_dialog: false,
-      config_to_load: null,
-      search: "",
-      expansionPanelState: ["configs"],
-    } as {
-      show_dialog: boolean;
-      config_to_load: string | null;
-      search: string;
-      expansionPanelState: string[];
-    };
-  },
-  computed: {
-    current_config(): EVConfigModel | null {
-      return evbcStore.current_config;
-    },
-    show_search(): boolean {
-      return !evbcStore.get_selected_terminal();
-    },
-    filtered_module_list(): Array<{ type: string; description: string }> {
-      const selectedTerminal = evbcStore.get_selected_terminal();
-      if (selectedTerminal) {
-        return Object.entries(evbc.everest_definitions.modules)
-          .filter(([, value]) => {
-            if (selectedTerminal.type === "requirement") {
-              return (
-                value.provides && Object.values(value.provides).some((e) => e.interface === selectedTerminal.interface)
-              );
-            } else {
-              return (
-                value.requires && Object.values(value.requires).some((e) => e.interface === selectedTerminal.interface)
-              );
-            }
-          })
-          .map(([key, value]) => ({
-            type: key,
-            description: value.description,
-          }));
-      } else {
-        return Object.entries(evbc.everest_definitions.modules)
-          .filter(([key, value]) => {
-            return (
-              !this.search ||
-              this.search.trim() === "" ||
-              key.toLowerCase().includes(this.search.toLowerCase()) ||
-              value.description.toLowerCase().includes(this.search.toLowerCase())
-            );
-          })
-          .map(([key, value]) => ({
-            type: key,
-            description: value.description,
-          }));
-      }
-    },
-    config_list(): Array<string> {
-      return Object.entries(evbcStore.available_configs).map(([key]) => key);
-    },
-  },
-  created() {
-    evbcStore = useEvbcStore();
-    evbc = inject<EVBackendClient>("evbc") as EVBackendClient;
-    notyf = inject<Notyf>("notyf");
-  },
-  methods: {
-    add_module_to_config(type: string) {
-      let added_module_id: number;
-      if (evbcStore.current_config) {
-        added_module_id = evbcStore.current_config.add_new_module_instance(type);
-      } else {
-        throw new Error("No config loaded");
-      }
-      if (evbcStore.get_selected_terminal()) {
-        const selectedTerminal = evbcStore.get_selected_terminal();
-        const addedModuleInstance = evbcStore.current_config.get_module_instance(added_module_id);
-        const terminals = Object.values(addedModuleInstance.view_config.terminals).flat();
-        let terminalToClick;
+const show_dialog = ref(false);
+const config_to_load = ref<string | null>(null);
+const search = ref("");
+const expansionPanelState = ref<string[]>(["configs"]);
+
+const current_config = computed<EVConfigModel | null>(() => evbcStore.current_config);
+const show_search = computed<boolean>(() => !evbcStore.get_selected_terminal());
+
+const filtered_module_list = computed(() => {
+  const selectedTerminal = evbcStore.get_selected_terminal();
+  if (selectedTerminal) {
+    return Object.entries(evbc.everest_definitions.modules)
+      .filter(([, value]) => {
         if (selectedTerminal.type === "requirement") {
-          terminalToClick = terminals.find((t) => t.interface === selectedTerminal.interface && t.type === "provide");
+          return (
+            value.provides && Object.values(value.provides).some((e) => e.interface === selectedTerminal.interface)
+          );
         } else {
-          terminalToClick = terminals.find(
-            (t) => t.interface === selectedTerminal.interface && t.type === "requirement",
+          return (
+            value.requires && Object.values(value.requires).some((e) => e.interface === selectedTerminal.interface)
           );
         }
-        evbcStore.get_config_context().clicked_terminal(terminalToClick, added_module_id);
-      }
-    },
-    create_config(name: string, content?: EverestConfig) {
-      const new_config = evbc.create_config_model(name, content);
-      evbcStore.setOpenedConfig(new_config);
-      this.expansionPanelState = ["modules"];
-    },
-    load_config_if_empty(name: string) {
-      if (!this.current_config) {
-        this.load_config(name);
-        return;
-      }
-      this.config_to_load = name;
-      this.show_dialog = true;
-    },
-    load_config(name: string | null) {
-      if (!name) {
-        return;
-      }
-      this.show_dialog = false;
-      const new_config = evbc.load_config(name);
-      evbcStore.setOpenedConfig(new_config);
-      this.expansionPanelState = ["modules"];
-    },
-    restart_modules() {
-      evbc._cxn.rpc_issuer.restart_modules().then(() => {
-        notyf.success("Issued restart modules command");
-      });
-    },
-    close_dialog() {
-      this.show_dialog = false;
-    },
-  },
+      })
+      .map(([key, value]) => ({
+        type: key,
+        description: value.description,
+      }));
+  } else {
+    return Object.entries(evbc.everest_definitions.modules)
+      .filter(([key, value]) => {
+        return (
+          !search.value ||
+          search.value.trim() === "" ||
+          key.toLowerCase().includes(search.value.toLowerCase()) ||
+          value.description.toLowerCase().includes(search.value.toLowerCase())
+        );
+      })
+      .map(([key, value]) => ({
+        type: key,
+        description: value.description,
+      }));
+  }
 });
+
+const config_list = computed(() => {
+  return Object.entries(evbcStore.available_configs).map(([key]) => key);
+});
+
+function add_module_to_config(type: string) {
+  let added_module_id: number;
+  if (evbcStore.current_config) {
+    added_module_id = evbcStore.current_config.add_new_module_instance(type);
+  } else {
+    throw new Error("No config loaded");
+  }
+  if (evbcStore.get_selected_terminal()) {
+    const selectedTerminal = evbcStore.get_selected_terminal();
+    const addedModuleInstance = evbcStore.current_config.get_module_instance(added_module_id);
+    const terminals = Object.values(addedModuleInstance.view_config.terminals).flat();
+    let terminalToClick;
+    if (selectedTerminal.type === "requirement") {
+      terminalToClick = terminals.find((t) => t.interface === selectedTerminal.interface && t.type === "provide");
+    } else {
+      terminalToClick = terminals.find((t) => t.interface === selectedTerminal.interface && t.type === "requirement");
+    }
+    evbcStore.get_config_context().clicked_terminal(terminalToClick, added_module_id);
+  }
+}
+
+function create_config(name: string, content?: EverestConfig) {
+  try {
+    const new_config = evbc.create_config_model(name, content);
+    evbcStore.setOpenedConfig(new_config);
+    expansionPanelState.value = ["modules"];
+  } catch (err) {
+    errorStore.setError(err.toString());
+    console.log(`error in config: ${errorStore.getError()}`);
+  }
+}
+
+function load_config_if_empty(name: string) {
+  if (!current_config.value) {
+    load_config(name);
+    return;
+  }
+  config_to_load.value = name;
+  show_dialog.value = true;
+}
+
+function load_config(name: string | null) {
+  if (!name) {
+    return;
+  }
+  show_dialog.value = false;
+  const new_config = evbc.load_config(name);
+  evbcStore.setOpenedConfig(new_config);
+  expansionPanelState.value = ["modules"];
+}
+
+function restart_modules() {
+  evbc._cxn.rpc_issuer.restart_modules().then(() => {
+    notyf.success("Issued restart modules command");
+  });
+}
+
+function close_dialog() {
+  show_dialog.value = false;
+}
 </script>
 
 <style>

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+ */
+
+import { defineStore } from "pinia";
+import { computed, ref, watch } from "vue";
+
+export const useErrorStore = defineStore("error", () => {
+  console.log("[Store] Initializing error store...");
+  const error = ref<string | null>(null);
+  watch(error, (newValue: string | null) => {
+    console.log("Error changed:", newValue);
+  });
+  // Inside useErrorStore
+  function setError(errorMessage: string) {
+    console.log("[Store] setError called with:", errorMessage); // <-- Add this
+    console.log("[Store] error.value BEFORE:", error.value); // <-- Add this
+    error.value = errorMessage;
+    console.log("[Store] error.value AFTER:", error.value); // <-- Add this
+  }
+
+  function clearError() {
+    console.trace("[Store] clearError called");
+    error.value = null;
+  }
+
+  const hasError = computed(() => {
+    return error.value !== null;
+  });
+
+  function getError() {
+    return error.value;
+  }
+
+  return {
+    error,
+    getError,
+    setError,
+    clearError,
+    hasError,
+  };
+});

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -4,24 +4,15 @@
  */
 
 import { defineStore } from "pinia";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 export const useErrorStore = defineStore("error", () => {
-  console.log("[Store] Initializing error store...");
   const error = ref<string | null>(null);
-  watch(error, (newValue: string | null) => {
-    console.log("Error changed:", newValue);
-  });
-  // Inside useErrorStore
   function setError(errorMessage: string) {
-    console.log("[Store] setError called with:", errorMessage); // <-- Add this
-    console.log("[Store] error.value BEFORE:", error.value); // <-- Add this
     error.value = errorMessage;
-    console.log("[Store] error.value AFTER:", error.value); // <-- Add this
   }
 
   function clearError() {
-    console.trace("[Store] clearError called");
     error.value = null;
   }
 


### PR DESCRIPTION
### TL;DR

Added a centralized error handling store and refactored the EvModuleList component to use the Composition API.

### What changed?

- Created a new `errorStore.ts` to centralize error handling across components
- Refactored `EvModuleList.vue` from Options API to Composition API
- Updated error handling in `CreateConfig.vue` to use the new error store
- Added proper error handling for config creation
- Added Cypress type reference to the config-management test file
- Fixed error display in the error dialog to use the new error store methods

### How to test?

1. Try creating a new configuration with invalid content
2. Verify that error messages are properly displayed
3. Test loading configurations and check that the error handling works correctly
4. Verify that the module list functionality still works as expected

### Why make this change?

This change improves error handling by centralizing it in a dedicated store, making it more consistent across the application. The refactoring of EvModuleList to use the Composition API improves code readability and maintainability. These changes make the codebase more robust and easier to maintain in the future.