### PR TITLE
feat: show error message when loading a config failed

### DIFF
--- a/src/components/EvModuleList.vue
+++ b/src/components/EvModuleList.vue
@@ -193,9 +193,13 @@ function load_config(name: string | null) {
     return;
   }
   show_dialog.value = false;
-  const new_config = evbc.load_config(name);
-  evbcStore.setOpenedConfig(new_config);
-  expansionPanelState.value = ["modules"];
+  try {
+    const new_config = evbc.load_config(name);
+    evbcStore.setOpenedConfig(new_config);
+    expansionPanelState.value = ["modules"];
+  } catch (err) {
+    errorStore.setError(err.toString());
+  }
 }
 
 function restart_modules() {


### PR DESCRIPTION
Added error handling when loading configuration

This PR adds a try-catch block around the configuration loading process to properly handle errors. When an error occurs during `evbc.load_config()`, it now captures the error and passes it to the error store instead of crashing.

Signed-off-by: 12fab4 <mailfuerfabian@web.de>